### PR TITLE
document: add bootstrap style to ensure summernote display properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ new webpack.ProvidePlugin({
 ```javascript
 import React from "react";
 import ReactSummernote from "react-summernote";
+import "bootstrap/dist/css/bootstrap.css"; // import bootstrap styles
 import "react-summernote/lang/summernote-ru-RU"; // you can import any other locale
 import "react-summernote/dist/react-summernote.css"; // import styles
 


### PR DESCRIPTION
When using your react-summernote, after setup anything base on your document. Summernote run but missing many styling. After compare to summernote on it's official site. I found that it depend on bootstrap and we must to include bootstrap styles for summernote display properly.