### PR TITLE
Bump to Summernote v0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "summernote-webpack-fix": "^0.8.1",
+    "summernote": "^0.8.2",
     "codemirror": "^5.11.0"
   },
   "peerDependencies": {

--- a/src/Summernote.jsx
+++ b/src/Summernote.jsx
@@ -1,7 +1,7 @@
 /* global $ */
 
-import 'summernote-webpack-fix/dist/summernote';
-import 'summernote-webpack-fix/dist/summernote.css';
+import 'summernote/dist/summernote';
+import 'summernote/dist/summernote.css';
 import 'codemirror/lib/codemirror.css';
 import React, { Component, PropTypes } from 'react';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
       jQuery: 'jquery'
     }),
     new CopyWebpackPlugin([{
-      from: 'node_modules/summernote-webpack-fix/dist/lang', to: '../lang'
+      from: 'node_modules/summernote/dist/lang', to: '../lang'
     }]),
     new ExtractTextPlugin('[name].css')
   ],


### PR DESCRIPTION
See Readme for https://github.com/cpbotha/summernote

Summernote 0.8.2 has landed on npm and we should use that instead of the fork